### PR TITLE
Insere tribunais federais e resolve pequenos bugs em transform_load

### DIFF
--- a/src/fetch.sh
+++ b/src/fetch.sh
@@ -9,7 +9,7 @@ BASE_URL="https://cloud5.lsd.ufcg.edu.br:8080/swift/v1/dadosjusbr"
 anos=`seq 2018 2020`
 
 # LISTA DE ÓRGÃOS
-orgaos="trepb mppb trt13 tjpb"
+orgaos="trepb mppb trt13 tjpb mpf mpm"
 
 for ano in $anos; do
     for mes in `seq 1 12`; do

--- a/src/transform_load.R
+++ b/src/transform_load.R
@@ -1,5 +1,6 @@
 #!/usr/bin/env Rscript
-
+library(dplyr)
+library(tidyr)
 library(readr)
 library(magrittr)
 library(purrr, warn.conflicts = F)


### PR DESCRIPTION
Incluído tribunais federais MPF e MPM em `./src/fetch.sh`. Fix bug em `./src/transform_load.R` inserindo bibliotecas `dplyr` e `tidyr`.